### PR TITLE
fix(build): align directoryEntryPaths with build input entries in vite.config.ts

### DIFF
--- a/scripts/lib/site-entries.js
+++ b/scripts/lib/site-entries.js
@@ -1,0 +1,51 @@
+import { resolve } from 'node:path'
+
+/**
+ * Declared HTML entries for the multi-page Vite application.
+ *
+ * Each entry specifies:
+ * - name: the chunk/input key passed to rollupOptions.input
+ * - html: the repository-relative path to the HTML entrypoint
+ */
+export const siteEntries = [
+  { name: 'main', html: 'index.html' },
+  { name: 'testing', html: 'public/testing.html' },
+  { name: 'dakota', html: 'dakota/index.html' },
+  { name: 'server', html: 'server/index.html' },
+  { name: 'wolves', html: 'wolves/index.html' },
+  { name: 'wolves/experience', html: 'wolves/experience/index.html' },
+]
+
+/**
+ * Builds the rollupOptions.input dictionary mapping entry names to absolute file paths.
+ *
+ * @param {string} rootDir
+ * @returns {Record<string, string>}
+ */
+export function createRollupInput(rootDir) {
+  const input = {}
+  for (const entry of siteEntries) {
+    input[entry.name] = resolve(rootDir, entry.html)
+  }
+  return input
+}
+
+/**
+ * Derives the set of directory paths that should redirect extension-less requests
+ * to their trailing-slash form during development (e.g. `/wolves` -> `/wolves/`).
+ *
+ * A directory entry is structurally defined as any entry whose html file ends in `/index.html`
+ * (excluding the root `index.html`), formatted as `/<directory-path>`.
+ *
+ * @returns {Set<string>}
+ */
+export function createDirectoryEntryPaths() {
+  const paths = new Set()
+  for (const entry of siteEntries) {
+    if (entry.html !== 'index.html' && entry.html.endsWith('/index.html')) {
+      const dirPath = '/' + entry.html.slice(0, -'/index.html'.length)
+      paths.add(dirPath)
+    }
+  }
+  return paths
+}

--- a/scripts/tests/site-entries.test.ts
+++ b/scripts/tests/site-entries.test.ts
@@ -1,0 +1,52 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createDirectoryEntryPaths,
+  createRollupInput,
+  siteEntries,
+} from '../lib/site-entries.js'
+
+describe('siteEntries', () => {
+  it('declares HTML files that exist on disk', () => {
+    const rootDir = resolve(import.meta.dirname, '../..')
+    for (const entry of siteEntries) {
+      const fullPath = resolve(rootDir, entry.html)
+      expect(existsSync(fullPath), `Entry ${entry.name} (${entry.html}) must exist`).toBe(true)
+    }
+  })
+
+  it('builds rollup input mapping all entries to absolute paths', () => {
+    const rootDir = '/fake/root'
+    const input = createRollupInput(rootDir)
+
+    expect(Object.keys(input)).toEqual([
+      'main',
+      'testing',
+      'dakota',
+      'server',
+      'wolves',
+      'wolves/experience',
+    ])
+    expect(input['main']).toBe('/fake/root/index.html')
+    expect(input['wolves/experience']).toBe('/fake/root/wolves/experience/index.html')
+  })
+
+  it('derives directoryEntryPaths including nested directories like /wolves/experience', () => {
+    const dirPaths = createDirectoryEntryPaths()
+
+    expect(dirPaths).toBeInstanceOf(Set)
+    expect(dirPaths).toEqual(new Set([
+      '/dakota',
+      '/server',
+      '/wolves',
+      '/wolves/experience',
+    ]))
+    // Root index.html must not be in directoryEntryPaths
+    expect(dirPaths.has('')).toBe(false)
+    expect(dirPaths.has('/')).toBe(false)
+    // Non-directory entry like testing.html must not be in directoryEntryPaths
+    expect(dirPaths.has('/public/testing')).toBe(false)
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from 'vite'
-import { resolve } from 'node:path'
 import { fileURLToPath, URL } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import { createVitestExclude } from './scripts/lib/vitest-exclude.js'
+import { createDirectoryEntryPaths, createRollupInput } from './scripts/lib/site-entries.js'
 
-const directoryEntryPaths = new Set(['/dakota', '/server', '/wolves'])
+const directoryEntryPaths = createDirectoryEntryPaths()
 
 function redirectDirectoryEntries(): Plugin {
   return {
@@ -72,14 +72,7 @@ export default defineConfig({
   ],
   build: {
     rollupOptions: {
-      input: {
-        'main': resolve(__dirname, 'index.html'),
-        'testing': resolve(__dirname, 'public/testing.html'),
-        'dakota': resolve(__dirname, 'dakota/index.html'),
-        'server': resolve(__dirname, 'server/index.html'),
-        'wolves': resolve(__dirname, 'wolves/index.html'),
-        'wolves/experience': resolve(__dirname, 'wolves/experience/index.html'),
-      },
+      input: createRollupInput(__dirname),
       output: {
         manualChunks: (id: string) => {
           if (['vue', 'vue-i18n'].some(mod => id.includes(`/node_modules/${mod}`))) {


### PR DESCRIPTION
## Description

Closes projectbluefin/website#776

In `vite.config.ts`, the multi-page entry set was declared twice: once in `build.rollupOptions.input` and once in `directoryEntryPaths`. This led to drift where `/wolves/experience` was present in `build.rollupOptions.input` but absent from `directoryEntryPaths`.

This PR consolidates the entry declarations into `scripts/lib/site-entries.js` following the recommendation in #776:
- Exports `siteEntries` defining each page entrypoint (`name` and `html` path).
- Exports `createRollupInput(rootDir)` to derive `rollupOptions.input`.
- Exports `createDirectoryEntryPaths()` which derives directory paths from any non-root entry ending with `/index.html`, automatically including `/dakota`, `/server`, `/wolves`, and `/wolves/experience`.
- Updates `vite.config.ts` to consume both functions.
- Adds comprehensive unit tests in `scripts/tests/site-entries.test.ts` verifying all declared HTML entries exist on disk and that derived rollup and directory inputs match expected paths.