### PR TITLE
fix(wolves): register arthur-c-clarke-4 in lore manifest

### DIFF
--- a/src/data/wolves-lore-records.ts
+++ b/src/data/wolves-lore-records.ts
@@ -353,6 +353,7 @@ const loreManifest = [
   { id: 'forbidden-factory', chapterId: 'prologue', relativePath: './lore/forbidden-factory.md' },
   { id: 'jordan-adrian', chapterId: 'prologue', relativePath: './lore/sidebar-comm-forbidden-factory-14.md' },
   { id: 'arthur-c-clarke-3', chapterId: 'prologue', relativePath: './lore/arthur-c-clarke-3.md' },
+  { id: 'arthur-c-clarke-4', chapterId: 'prologue', relativePath: './lore/arthur-c-clarke-4.md' },
   { id: 'maintenance-window', chapterId: 'prologue', relativePath: './lore/maintenance-window.md' },
   { id: 'quote-childhoods-end-future', chapterId: 'pursuit', relativePath: './lore/quote-childhoods-end-future.md' },
   { id: 'lorem-pursuit-1', chapterId: 'pursuit', relativePath: './lore/lorem-pursuit-1.md' },

--- a/src/tests/wolvesLoreColumn.test.ts
+++ b/src/tests/wolvesLoreColumn.test.ts
@@ -217,7 +217,7 @@ describe('wolvesLoreColumn Logic', () => {
       .map(record => record.id))
     const quoteArtifacts = wolvesRelease.artifacts.filter(artifact => quoteIds.has(artifact.id))
 
-    expect(quoteArtifacts).toHaveLength(17)
+    expect(quoteArtifacts).toHaveLength(18)
     expect(quoteArtifacts.every(artifact => !Object.prototype.hasOwnProperty.call(artifact, 'sourceLabel'))).toBe(true)
   })
 

--- a/src/tests/wolvesLoreRecords.test.ts
+++ b/src/tests/wolvesLoreRecords.test.ts
@@ -79,7 +79,7 @@ describe('wolves lore records', () => {
     const laura = records.find(record => record.id === 'laura-sherman-robert')
     const openssf = records.find(record => record.id === 'openssf-reinforcements')
 
-    expect(records).toHaveLength(64)
+    expect(records).toHaveLength(65)
     expect(records.flatMap(record => record.diagnostics)).toEqual([])
     expect(artifact).toMatchObject({
       chapterId: 'prologue',
@@ -130,7 +130,7 @@ describe('wolves lore records', () => {
   it('loads every quote with authored identity and no diagnostics', () => {
     const quotes = loadAllLoreRecords().filter(record => record.kind === 'quote')
 
-    expect(quotes).toHaveLength(17)
+    expect(quotes).toHaveLength(18)
     for (const quote of quotes) {
       expect(quote.metadata.attribution, quote.relativePath).toEqual(expect.any(String))
       expect(quote.metadata.attribution?.trim(), quote.relativePath).not.toBe('')

--- a/src/tests/wolvesStory.test.ts
+++ b/src/tests/wolvesStory.test.ts
@@ -20,6 +20,7 @@ describe('wolves story manifest', () => {
         'forbidden-factory',
         'jordan-adrian',
         'arthur-c-clarke-3',
+        'arthur-c-clarke-4',
         'maintenance-window'
       ])
   })


### PR DESCRIPTION
Registers `src/data/lore/arthur-c-clarke-4.md` in the lore manifest table in `src/data/wolves-lore-records.ts` following the pattern of `arthur-c-clarke-1`, `2`, and `3` under the `prologue` chapter. Updates related test assertions to reflect the 65 total records and 18 quote artifacts.

Closes projectbluefin/website#755