### PR TITLE
fix(wolves): resolve album slide skipping and decouple timing from wolves manifest

### DIFF
--- a/docs/reference/wolves-slide-scheduling.md
+++ b/docs/reference/wolves-slide-scheduling.md
@@ -210,22 +210,19 @@ wallpaper dissolves against a window the deck is not using.
 ## Albums borrow the Wolves manifest's tempo by index
 
 `currentTrack` resolves the Wolves show by **identity** (`trackId`), which is
-correct and load-bearing. Its fallback is `manifest.tracks[trackIndex]`, and
-that fallback is what every other album gets — so an unrelated album's track 3
-is paced by the BPM and `phraseBeats` of *Wolves* track 3, which is the only
-manifest ever loaded. It is clamped to 5.5–11.5 s by `laterTrackSlideHold`, so
-it degrades to a plausible-looking hold rather than an obvious break.
+correct and load-bearing. Previously, its fallback was `manifest.tracks[trackIndex]`,
+and that fallback was what every other album got — so an unrelated album's track 3
+was paced by the BPM and `phraseBeats` of *Wolves* track 3, which is the only
+manifest ever loaded.
 
-Two consequences worth knowing before touching slide pacing:
+Album experiences are now decoupled from the Wolves soundtrack manifest:
+`currentTrack` resolves only for `isWolvesExperience`, and `laterTrackSlideHold`
+uses the stable `[7, 8, 10][trackIndex % 3]` hold cadence for albums. This prevents
+two bugs:
 
-- Album slide pacing is not derived from the album. It is a foreign tempo.
-- `manifest` loads asynchronously, so `currentTrack` is null until it lands.
-  The hold therefore changes from the `[7, 8, 10]` fallback to the BPM-derived
-  value mid-track, and `activeFlickrIndex` is `floor(time / hold)` — a hold
-  that changes under a running clock moves the index discontinuously. That is a
-  one-time jump per run, not a steady drift, which is exactly the kind of
-  symptom that gets reported as "it skipped" and then fails to reproduce.
-
+1. Album slide pacing no longer borrows a foreign tempo from the Wolves manifest.
+2. Asynchronous loading of `manifest` no longer alters the hold divisor under a
+   running player clock, eliminating discontinuous jumps in `activeFlickrIndex`.
 ## WolvesComicReader serves more than Wolves
 
 `WolvesComicReader.vue` drives three different shows and only one is the

--- a/src/components/wolves/WolvesComicReader.vue
+++ b/src/components/wolves/WolvesComicReader.vue
@@ -241,9 +241,12 @@ const currentTrack = computed<SoundtrackTrack | null>(() => {
   //
   // The lookup is confined to the Wolves experience because the other albums in
   // public/experiences/catalogue.json share youtube ids with unrelated entries
-  // further down this same playlist; for them a segment index is the intended
-  // addressing scheme and must keep working unchanged.
-  if (isWolvesExperience.value && props.trackId) {
+  // further down this same playlist; for them the Wolves soundtrack manifest is
+  // unrelated and must not be used to pace album slides.
+  if (!isWolvesExperience.value) {
+    return null
+  }
+  if (props.trackId) {
     const identified = manifest.value.tracks.find(
       track => track.youtubeVideoId === props.trackId || track.id === props.trackId,
     )
@@ -255,7 +258,6 @@ const currentTrack = computed<SoundtrackTrack | null>(() => {
     return null
   }
   return manifest.value.tracks[props.trackIndex] || null
-})
 
 const currentBeat = computed(() => {
   const bpm = currentTrack.value?.bpm
@@ -867,6 +869,13 @@ const laterTrackSlideHold = computed(() => {
   const trackIndex = props.trackIndex ?? 0
   if (trackIndex <= 0) {
     return null
+  }
+
+  // Generic album experiences do not load a soundtrack manifest and run on a
+  // fixed, stable slide cadence that does not borrow Wolves tempo or jump when
+  // manifest loads asynchronously.
+  if (!isWolvesExperience.value) {
+    return [7, 8, 10][trackIndex % 3]
   }
 
   const track = currentTrack.value

--- a/src/tests/wolvesComicReader.test.ts
+++ b/src/tests/wolvesComicReader.test.ts
@@ -1306,22 +1306,22 @@ describe('wolves segment-to-playlist track identity', () => {
     expect(wrapper.props('trackIndex')).toBe(6)
   })
 
-  it('leaves the ten catalogue albums on index-addressed playlist metadata', async () => {
+  it('decouples catalogue album pacing from Wolves soundtrack manifest', async () => {
     const tracks: SoundtrackTrack[] = [
       coverTrack,
       {
-        id: 'album-track-one',
-        title: 'Album Track One',
+        id: 'wolves-track-one',
+        title: 'Wolves Track One',
         artist: 'Artist',
         artwork: 'wolves-artwork/album-one.jpg',
         youtubeVideoId: 'album-one',
-        bpm: 120,
+        bpm: 180,
         phraseBeats: 32,
         fadeDuration: 1500,
       },
       {
-        id: 'decoy',
-        title: 'Decoy',
+        id: 'wolves-track-two',
+        title: 'Wolves Track Two',
         artist: 'Artist',
         artwork: 'wolves-artwork/decoy.jpg',
         youtubeVideoId: 'decoy-id',
@@ -1332,8 +1332,8 @@ describe('wolves segment-to-playlist track identity', () => {
     ]
     mockGalleryData(tracks)
 
-    // A catalogue album's segment youtubeId can also appear elsewhere in this
-    // playlist, so identity resolution must not apply outside the Wolves show.
+    // Back-catalogue albums do not borrow the Wolves manifest BPM/metadata,
+    // keeping holds stable across async manifest loading.
     const wrapper = mount(WolvesComicReader, {
       props: {
         trackIndex: 1,
@@ -1345,8 +1345,65 @@ describe('wolves segment-to-playlist track identity', () => {
     })
     await flushPromises()
 
-    expect(((wrapper.vm as any).currentTrack as SoundtrackTrack).id).toBe('album-track-one')
-    expect((wrapper.vm as any).laterTrackSlideHold as number).toBeCloseTo(8, 4)
+    expect((wrapper.vm as any).currentTrack).toBeNull()
+    // trackIndex 1 -> [7, 8, 10][1 % 3] = 8
+    expect((wrapper.vm as any).laterTrackSlideHold as number).toBe(8)
+    expect((wrapper.vm as any).standardSlideHold as number).toBe(8)
+  })
+
+  it('ensures activeFlickrIndex never skips discontinuously across manifest resolution', async () => {
+    let resolveManifest: (value: any) => void = () => {}
+    const manifestPromise = new Promise((resolve) => {
+      resolveManifest = resolve
+    })
+
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (url.includes('wolves-playlist.json')) {
+        return manifestPromise
+      }
+      if (url.includes('flickr-photos.json')) {
+        return Promise.resolve(new Response(JSON.stringify(galleryPhotos)))
+      }
+      return Promise.resolve(new Response(JSON.stringify({})))
+    }))
+
+    const wrapper = mount(WolvesComicReader, {
+      props: {
+        trackIndex: 1,
+        trackId: 'catalogue-video-id',
+        playlistCurrentTime: 10,
+        experienceId: 'album-test',
+        wolvesExperience: false,
+      },
+    })
+    await nextTick()
+
+    // Before manifest loads: hold is [7, 8, 10][1 % 3] = 8, at 10s -> Math.floor(10 / 8) = 1
+    const indexBefore = (wrapper.vm as any).activeFlickrIndex
+    expect(indexBefore).toBe(1)
+
+    // Resolve manifest with high BPM track that would produce a different hold if borrowed
+    resolveManifest(new Response(JSON.stringify({
+      source,
+      tracks: [
+        coverTrack,
+        {
+          id: 'wolves-high-bpm',
+          title: 'High BPM',
+          artist: 'Artist',
+          artwork: 'artwork.jpg',
+          youtubeVideoId: 'catalogue-video-id',
+          bpm: 180,
+          phraseBeats: 32,
+        },
+      ],
+    })))
+    await flushPromises()
+
+    // After manifest loads: hold must remain decoupled and stable
+    const indexAfter = (wrapper.vm as any).activeFlickrIndex
+    expect((wrapper.vm as any).laterTrackSlideHold).toBe(8)
+    expect(indexAfter).toBe(1)
   })
 
   it('keeps the non-Wolves albums on the mixedPhotos slideshow at index 0', async () => {


### PR DESCRIPTION
Decouple album slide pacing from the Wolves soundtrack manifest to resolve slide skipping.

### Changes
- In `WolvesComicReader.vue`, guard `currentTrack` lookup so that generic album experiences (`!isWolvesExperience`) do not borrow playlist metadata by index from the Wolves soundtrack manifest.
- Update `laterTrackSlideHold` so generic album playback always runs on the stable fallback cadence `[7, 8, 10][trackIndex % 3]` without relying on Wolves BPM calculations.
- This prevents the hold divisor from changing under a running clock when `manifest` finishes loading asynchronously, eliminating discontinuous skips in `activeFlickrIndex`.
- Update `wolvesComicReader.test.ts` unit tests to assert hold decoupling and verify that `activeFlickrIndex` does not skip discontinuously across manifest resolution.
- Update `docs/reference/wolves-slide-scheduling.md` to document the decoupling.

Closes projectbluefin/website#748