### PR TITLE
fix: consolidate final-review batch — vite entries, pinned growth chart, drift gate, lore registration, album pacing

### DIFF
--- a/.github/workflows/update-content.yml
+++ b/.github/workflows/update-content.yml
@@ -63,9 +63,7 @@ jobs:
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
 
       - name: Download Bluefin Growth Chart
-        run: |
-          curl https://raw.githubusercontent.com/ublue-os/countme/refs/heads/main/growth_bluefins.svg --output src/assets/svg/growth_bluefins.svg
-          sed -i 's/#ffffff/#0c1016/g; s/#cccccc/#272727/g; s/#616161/#bdbdbd/g; s/#77aadd/#4285f4/g; s/id="text_16">/id="text_16" style="fill: #bdbdbd">/' src/assets/svg/growth_bluefins.svg
+        run: node scripts/update-growth-chart.js
 
       - name: Verify image SBOMs and update version data
         run: npm run update:image-versions

--- a/docs/reference/wolves-slide-scheduling.md
+++ b/docs/reference/wolves-slide-scheduling.md
@@ -210,22 +210,19 @@ wallpaper dissolves against a window the deck is not using.
 ## Albums borrow the Wolves manifest's tempo by index
 
 `currentTrack` resolves the Wolves show by **identity** (`trackId`), which is
-correct and load-bearing. Its fallback is `manifest.tracks[trackIndex]`, and
-that fallback is what every other album gets — so an unrelated album's track 3
-is paced by the BPM and `phraseBeats` of *Wolves* track 3, which is the only
-manifest ever loaded. It is clamped to 5.5–11.5 s by `laterTrackSlideHold`, so
-it degrades to a plausible-looking hold rather than an obvious break.
+correct and load-bearing. Previously, its fallback was `manifest.tracks[trackIndex]`,
+and that fallback was what every other album got — so an unrelated album's track 3
+was paced by the BPM and `phraseBeats` of *Wolves* track 3, which is the only
+manifest ever loaded.
 
-Two consequences worth knowing before touching slide pacing:
+Album experiences are now decoupled from the Wolves soundtrack manifest:
+`currentTrack` resolves only for `isWolvesExperience`, and `laterTrackSlideHold`
+uses the stable `[7, 8, 10][trackIndex % 3]` hold cadence for albums. This prevents
+two bugs:
 
-- Album slide pacing is not derived from the album. It is a foreign tempo.
-- `manifest` loads asynchronously, so `currentTrack` is null until it lands.
-  The hold therefore changes from the `[7, 8, 10]` fallback to the BPM-derived
-  value mid-track, and `activeFlickrIndex` is `floor(time / hold)` — a hold
-  that changes under a running clock moves the index discontinuously. That is a
-  one-time jump per run, not a steady drift, which is exactly the kind of
-  symptom that gets reported as "it skipped" and then fails to reproduce.
-
+1. Album slide pacing no longer borrows a foreign tempo from the Wolves manifest.
+2. Asynchronous loading of `manifest` no longer alters the hold divisor under a
+   running player clock, eliminating discontinuous jumps in `activeFlickrIndex`.
 ## WolvesComicReader serves more than Wolves
 
 `WolvesComicReader.vue` drives three different shows and only one is the

--- a/scripts/lib/site-entries.js
+++ b/scripts/lib/site-entries.js
@@ -43,7 +43,7 @@ export function createDirectoryEntryPaths() {
   const paths = new Set()
   for (const entry of siteEntries) {
     if (entry.html !== 'index.html' && entry.html.endsWith('/index.html')) {
-      const dirPath = '/' + entry.html.slice(0, -'/index.html'.length)
+      const dirPath = `/${entry.html.slice(0, -'/index.html'.length)}`
       paths.add(dirPath)
     }
   }

--- a/scripts/lib/site-entries.js
+++ b/scripts/lib/site-entries.js
@@ -1,0 +1,51 @@
+import { resolve } from 'node:path'
+
+/**
+ * Declared HTML entries for the multi-page Vite application.
+ *
+ * Each entry specifies:
+ * - name: the chunk/input key passed to rollupOptions.input
+ * - html: the repository-relative path to the HTML entrypoint
+ */
+export const siteEntries = [
+  { name: 'main', html: 'index.html' },
+  { name: 'testing', html: 'public/testing.html' },
+  { name: 'dakota', html: 'dakota/index.html' },
+  { name: 'server', html: 'server/index.html' },
+  { name: 'wolves', html: 'wolves/index.html' },
+  { name: 'wolves/experience', html: 'wolves/experience/index.html' },
+]
+
+/**
+ * Builds the rollupOptions.input dictionary mapping entry names to absolute file paths.
+ *
+ * @param {string} rootDir
+ * @returns {Record<string, string>}
+ */
+export function createRollupInput(rootDir) {
+  const input = {}
+  for (const entry of siteEntries) {
+    input[entry.name] = resolve(rootDir, entry.html)
+  }
+  return input
+}
+
+/**
+ * Derives the set of directory paths that should redirect extension-less requests
+ * to their trailing-slash form during development (e.g. `/wolves` -> `/wolves/`).
+ *
+ * A directory entry is structurally defined as any entry whose html file ends in `/index.html`
+ * (excluding the root `index.html`), formatted as `/<directory-path>`.
+ *
+ * @returns {Set<string>}
+ */
+export function createDirectoryEntryPaths() {
+  const paths = new Set()
+  for (const entry of siteEntries) {
+    if (entry.html !== 'index.html' && entry.html.endsWith('/index.html')) {
+      const dirPath = '/' + entry.html.slice(0, -'/index.html'.length)
+      paths.add(dirPath)
+    }
+  }
+  return paths
+}

--- a/scripts/lib/site-entries.js
+++ b/scripts/lib/site-entries.js
@@ -20,7 +20,7 @@ export const siteEntries = [
  * Builds the rollupOptions.input dictionary mapping entry names to absolute file paths.
  *
  * @param {string} rootDir
- * @returns {Record<string, string>}
+ * @returns {Record<string, string>} Map of entry names to resolved absolute file paths.
  */
 export function createRollupInput(rootDir) {
   const input = {}
@@ -37,7 +37,7 @@ export function createRollupInput(rootDir) {
  * A directory entry is structurally defined as any entry whose html file ends in `/index.html`
  * (excluding the root `index.html`), formatted as `/<directory-path>`.
  *
- * @returns {Set<string>}
+ * @returns {Set<string>} Set of root-relative directory paths requiring trailing-slash redirects.
  */
 export function createDirectoryEntryPaths() {
   const paths = new Set()

--- a/scripts/tests/site-entries.test.ts
+++ b/scripts/tests/site-entries.test.ts
@@ -29,7 +29,7 @@ describe('siteEntries', () => {
       'wolves',
       'wolves/experience',
     ])
-    expect(input['main']).toBe('/fake/root/index.html')
+    expect(input.main).toBe('/fake/root/index.html')
     expect(input['wolves/experience']).toBe('/fake/root/wolves/experience/index.html')
   })
 

--- a/scripts/tests/site-entries.test.ts
+++ b/scripts/tests/site-entries.test.ts
@@ -1,0 +1,52 @@
+import { existsSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  createDirectoryEntryPaths,
+  createRollupInput,
+  siteEntries,
+} from '../lib/site-entries.js'
+
+describe('siteEntries', () => {
+  it('declares HTML files that exist on disk', () => {
+    const rootDir = resolve(import.meta.dirname, '../..')
+    for (const entry of siteEntries) {
+      const fullPath = resolve(rootDir, entry.html)
+      expect(existsSync(fullPath), `Entry ${entry.name} (${entry.html}) must exist`).toBe(true)
+    }
+  })
+
+  it('builds rollup input mapping all entries to absolute paths', () => {
+    const rootDir = '/fake/root'
+    const input = createRollupInput(rootDir)
+
+    expect(Object.keys(input)).toEqual([
+      'main',
+      'testing',
+      'dakota',
+      'server',
+      'wolves',
+      'wolves/experience',
+    ])
+    expect(input['main']).toBe('/fake/root/index.html')
+    expect(input['wolves/experience']).toBe('/fake/root/wolves/experience/index.html')
+  })
+
+  it('derives directoryEntryPaths including nested directories like /wolves/experience', () => {
+    const dirPaths = createDirectoryEntryPaths()
+
+    expect(dirPaths).toBeInstanceOf(Set)
+    expect(dirPaths).toEqual(new Set([
+      '/dakota',
+      '/server',
+      '/wolves',
+      '/wolves/experience',
+    ]))
+    // Root index.html must not be in directoryEntryPaths
+    expect(dirPaths.has('')).toBe(false)
+    expect(dirPaths.has('/')).toBe(false)
+    // Non-directory entry like testing.html must not be in directoryEntryPaths
+    expect(dirPaths.has('/public/testing')).toBe(false)
+  })
+})

--- a/scripts/tests/version-projection-drift.test.ts
+++ b/scripts/tests/version-projection-drift.test.ts
@@ -1,0 +1,105 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { IMAGE_SBOM_REGISTRY } from '../lib/image-sbom-registry.js'
+
+describe('version projection and consumer drift gate', () => {
+  const rootDir = join(import.meta.dirname, '../..')
+
+  const dakotaRegistryKeys = new Set(
+    IMAGE_SBOM_REGISTRY.filter(r => r.product === 'dakota')
+      .flatMap(r => Object.keys(r.packages)),
+  )
+
+  const bluefinRegistryKeys = new Set(
+    IMAGE_SBOM_REGISTRY.filter(r => r.product === 'bluefin')
+      .flatMap(r => Object.keys(r.packages)),
+  )
+
+  it('registry defines expected base package sets for both products', () => {
+    expect(dakotaRegistryKeys.size).toBeGreaterThan(0)
+    expect(bluefinRegistryKeys.size).toBeGreaterThan(0)
+    expect(dakotaRegistryKeys).toContain('kernel')
+    expect(bluefinRegistryKeys).toContain('kernel')
+  })
+
+  it('every DAKOTA_KEYS entry in SectionPicker.vue resolves to a dakota registry field', () => {
+    const sectionPickerSource = readFileSync(
+      join(rootDir, 'src/components/sections/SectionPicker.vue'),
+      'utf8',
+    )
+    const dakotaKeysMatch = sectionPickerSource.match(/const\s+DAKOTA_KEYS\s*=\s*\[([\s\S]*?)\]/)
+    expect(dakotaKeysMatch, 'Could not find DAKOTA_KEYS in SectionPicker.vue').not.toBeNull()
+
+    const dakotaKeys = dakotaKeysMatch![1]
+      .split(',')
+      .map(k => k.trim().replace(/['"]/g, ''))
+      .filter(Boolean)
+
+    expect(dakotaKeys.length).toBeGreaterThan(0)
+    for (const key of dakotaKeys) {
+      expect(
+        dakotaRegistryKeys.has(key),
+        `DAKOTA_KEYS entry "${key}" in SectionPicker.vue must resolve to a dakota package in IMAGE_SBOM_REGISTRY`,
+      ).toBe(true)
+    }
+  })
+
+  it('every PACKAGE_LABELS entry in SectionPicker.vue resolves to a dakota registry field', () => {
+    const sectionPickerSource = readFileSync(
+      join(rootDir, 'src/components/sections/SectionPicker.vue'),
+      'utf8',
+    )
+    const packageLabelsMatch = sectionPickerSource.match(
+      /const\s+PACKAGE_LABELS:\s*Record<string,\s*string>\s*=\s*\{([\s\S]*?)\n\}/,
+    )
+    expect(packageLabelsMatch, 'Could not find PACKAGE_LABELS in SectionPicker.vue').not.toBeNull()
+
+    const packageLabelKeys = packageLabelsMatch![1]
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('//'))
+      .map(line => line.split(':')[0].trim().replace(/['"]/g, ''))
+      .filter(Boolean)
+
+    expect(packageLabelKeys.length).toBeGreaterThan(0)
+    for (const key of packageLabelKeys) {
+      expect(
+        dakotaRegistryKeys.has(key),
+        `PACKAGE_LABELS entry "${key}" in SectionPicker.vue must resolve to a dakota package in IMAGE_SBOM_REGISTRY`,
+      ).toBe(true)
+    }
+  })
+
+  it('every VersionInfo field in ImageChooser.vue resolves to a bluefin registry field or synthesized projection key', () => {
+    const imageChooserSource = readFileSync(
+      join(rootDir, 'src/components/ImageChooser.vue'),
+      'utf8',
+    )
+    const versionInfoMatch = imageChooserSource.match(/interface\s+VersionInfo\s*\{([\s\S]*?)\}/)
+    expect(versionInfoMatch, 'Could not find VersionInfo in ImageChooser.vue').not.toBeNull()
+
+    const versionInfoKeys = versionInfoMatch![1]
+      .split('\n')
+      .map(line => line.trim())
+      .filter(line => line && !line.startsWith('//'))
+      .map(line => line.replace(/[?:].*$/, '').trim())
+      .filter(Boolean)
+
+    expect(versionInfoKeys.length).toBeGreaterThan(0)
+
+    // Allowed fields on VersionInfo:
+    // - bluefin packages defined in IMAGE_SBOM_REGISTRY
+    // - status (projection status: 'verified' | 'unavailable')
+    // - hwe (synthesized from bluefin-lts-hwe in projectBluefinStreams)
+    const allowedBluefinKeys = new Set([...bluefinRegistryKeys, 'status', 'hwe'])
+
+    for (const key of versionInfoKeys) {
+      expect(
+        allowedBluefinKeys.has(key),
+        `VersionInfo key "${key}" in ImageChooser.vue must resolve to a bluefin package in IMAGE_SBOM_REGISTRY or synthesized key`,
+      ).toBe(true)
+    }
+  })
+})

--- a/src/components/sections/SectionPicker.vue
+++ b/src/components/sections/SectionPicker.vue
@@ -27,7 +27,7 @@ const PACKAGE_LABELS: Record<string, string> = {
 }
 
 // Kernel/init first, then graphics, then desktop. Every key here must be
-// resolvable from the image SBOM — see scripts/update-dakota-versions.js.
+// resolvable from the image SBOM — see scripts/lib/image-sbom-registry.js.
 const DAKOTA_KEYS = ['kernel', 'systemd', 'bootc', 'mesa', 'nvidia', 'gnome', 'pipewire']
 
 async function loadVersions() {

--- a/src/components/wolves/WolvesComicReader.vue
+++ b/src/components/wolves/WolvesComicReader.vue
@@ -241,9 +241,12 @@ const currentTrack = computed<SoundtrackTrack | null>(() => {
   //
   // The lookup is confined to the Wolves experience because the other albums in
   // public/experiences/catalogue.json share youtube ids with unrelated entries
-  // further down this same playlist; for them a segment index is the intended
-  // addressing scheme and must keep working unchanged.
-  if (isWolvesExperience.value && props.trackId) {
+  // further down this same playlist; for them the Wolves soundtrack manifest is
+  // unrelated and must not be used to pace album slides.
+  if (!isWolvesExperience.value) {
+    return null
+  }
+  if (props.trackId) {
     const identified = manifest.value.tracks.find(
       track => track.youtubeVideoId === props.trackId || track.id === props.trackId,
     )
@@ -255,7 +258,6 @@ const currentTrack = computed<SoundtrackTrack | null>(() => {
     return null
   }
   return manifest.value.tracks[props.trackIndex] || null
-})
 
 const currentBeat = computed(() => {
   const bpm = currentTrack.value?.bpm
@@ -867,6 +869,13 @@ const laterTrackSlideHold = computed(() => {
   const trackIndex = props.trackIndex ?? 0
   if (trackIndex <= 0) {
     return null
+  }
+
+  // Generic album experiences do not load a soundtrack manifest and run on a
+  // fixed, stable slide cadence that does not borrow Wolves tempo or jump when
+  // manifest loads asynchronously.
+  if (!isWolvesExperience.value) {
+    return [7, 8, 10][trackIndex % 3]
   }
 
   const track = currentTrack.value

--- a/src/components/wolves/WolvesComicReader.vue
+++ b/src/components/wolves/WolvesComicReader.vue
@@ -258,6 +258,7 @@ const currentTrack = computed<SoundtrackTrack | null>(() => {
     return null
   }
   return manifest.value.tracks[props.trackIndex] || null
+})
 
 const currentBeat = computed(() => {
   const bpm = currentTrack.value?.bpm

--- a/src/components/wolves/lore/lore-pages.ts
+++ b/src/components/wolves/lore/lore-pages.ts
@@ -19,7 +19,7 @@ export const PROSE_PAGE_CHARACTERS = 190
  * the block gap, and the rounding of its last line. Counted per block so a page
  * budget predicts rendered height instead of raw character count.
  */
-const BLOCK_OVERHEAD_CHARACTERS = 40
+export const BLOCK_OVERHEAD_CHARACTERS = 40
 
 /** Floor for a page nobody in the back row should have to rush. */
 export const PAGE_MINIMUM_SECONDS = 6

--- a/src/data/wolves-lore-records.ts
+++ b/src/data/wolves-lore-records.ts
@@ -353,6 +353,7 @@ const loreManifest = [
   { id: 'forbidden-factory', chapterId: 'prologue', relativePath: './lore/forbidden-factory.md' },
   { id: 'jordan-adrian', chapterId: 'prologue', relativePath: './lore/sidebar-comm-forbidden-factory-14.md' },
   { id: 'arthur-c-clarke-3', chapterId: 'prologue', relativePath: './lore/arthur-c-clarke-3.md' },
+  { id: 'arthur-c-clarke-4', chapterId: 'prologue', relativePath: './lore/arthur-c-clarke-4.md' },
   { id: 'maintenance-window', chapterId: 'prologue', relativePath: './lore/maintenance-window.md' },
   { id: 'quote-childhoods-end-future', chapterId: 'pursuit', relativePath: './lore/quote-childhoods-end-future.md' },
   { id: 'lorem-pursuit-1', chapterId: 'pursuit', relativePath: './lore/lorem-pursuit-1.md' },

--- a/src/tests/wolvesComicReader.test.ts
+++ b/src/tests/wolvesComicReader.test.ts
@@ -1306,22 +1306,22 @@ describe('wolves segment-to-playlist track identity', () => {
     expect(wrapper.props('trackIndex')).toBe(6)
   })
 
-  it('leaves the ten catalogue albums on index-addressed playlist metadata', async () => {
+  it('decouples catalogue album pacing from Wolves soundtrack manifest', async () => {
     const tracks: SoundtrackTrack[] = [
       coverTrack,
       {
-        id: 'album-track-one',
-        title: 'Album Track One',
+        id: 'wolves-track-one',
+        title: 'Wolves Track One',
         artist: 'Artist',
         artwork: 'wolves-artwork/album-one.jpg',
         youtubeVideoId: 'album-one',
-        bpm: 120,
+        bpm: 180,
         phraseBeats: 32,
         fadeDuration: 1500,
       },
       {
-        id: 'decoy',
-        title: 'Decoy',
+        id: 'wolves-track-two',
+        title: 'Wolves Track Two',
         artist: 'Artist',
         artwork: 'wolves-artwork/decoy.jpg',
         youtubeVideoId: 'decoy-id',
@@ -1332,8 +1332,8 @@ describe('wolves segment-to-playlist track identity', () => {
     ]
     mockGalleryData(tracks)
 
-    // A catalogue album's segment youtubeId can also appear elsewhere in this
-    // playlist, so identity resolution must not apply outside the Wolves show.
+    // Back-catalogue albums do not borrow the Wolves manifest BPM/metadata,
+    // keeping holds stable across async manifest loading.
     const wrapper = mount(WolvesComicReader, {
       props: {
         trackIndex: 1,
@@ -1345,8 +1345,65 @@ describe('wolves segment-to-playlist track identity', () => {
     })
     await flushPromises()
 
-    expect(((wrapper.vm as any).currentTrack as SoundtrackTrack).id).toBe('album-track-one')
-    expect((wrapper.vm as any).laterTrackSlideHold as number).toBeCloseTo(8, 4)
+    expect((wrapper.vm as any).currentTrack).toBeNull()
+    // trackIndex 1 -> [7, 8, 10][1 % 3] = 8
+    expect((wrapper.vm as any).laterTrackSlideHold as number).toBe(8)
+    expect((wrapper.vm as any).standardSlideHold as number).toBe(8)
+  })
+
+  it('ensures activeFlickrIndex never skips discontinuously across manifest resolution', async () => {
+    let resolveManifest: (value: any) => void = () => {}
+    const manifestPromise = new Promise((resolve) => {
+      resolveManifest = resolve
+    })
+
+    vi.stubGlobal('fetch', vi.fn((url: string) => {
+      if (url.includes('wolves-playlist.json')) {
+        return manifestPromise
+      }
+      if (url.includes('flickr-photos.json')) {
+        return Promise.resolve(new Response(JSON.stringify(galleryPhotos)))
+      }
+      return Promise.resolve(new Response(JSON.stringify({})))
+    }))
+
+    const wrapper = mount(WolvesComicReader, {
+      props: {
+        trackIndex: 1,
+        trackId: 'catalogue-video-id',
+        playlistCurrentTime: 10,
+        experienceId: 'album-test',
+        wolvesExperience: false,
+      },
+    })
+    await nextTick()
+
+    // Before manifest loads: hold is [7, 8, 10][1 % 3] = 8, at 10s -> Math.floor(10 / 8) = 1
+    const indexBefore = (wrapper.vm as any).activeFlickrIndex
+    expect(indexBefore).toBe(1)
+
+    // Resolve manifest with high BPM track that would produce a different hold if borrowed
+    resolveManifest(new Response(JSON.stringify({
+      source,
+      tracks: [
+        coverTrack,
+        {
+          id: 'wolves-high-bpm',
+          title: 'High BPM',
+          artist: 'Artist',
+          artwork: 'artwork.jpg',
+          youtubeVideoId: 'catalogue-video-id',
+          bpm: 180,
+          phraseBeats: 32,
+        },
+      ],
+    })))
+    await flushPromises()
+
+    // After manifest loads: hold must remain decoupled and stable
+    const indexAfter = (wrapper.vm as any).activeFlickrIndex
+    expect((wrapper.vm as any).laterTrackSlideHold).toBe(8)
+    expect(indexAfter).toBe(1)
   })
 
   it('keeps the non-Wolves albums on the mixedPhotos slideshow at index 0', async () => {

--- a/src/tests/wolvesLoreColumn.test.ts
+++ b/src/tests/wolvesLoreColumn.test.ts
@@ -217,7 +217,7 @@ describe('wolvesLoreColumn Logic', () => {
       .map(record => record.id))
     const quoteArtifacts = wolvesRelease.artifacts.filter(artifact => quoteIds.has(artifact.id))
 
-    expect(quoteArtifacts).toHaveLength(17)
+    expect(quoteArtifacts).toHaveLength(18)
     expect(quoteArtifacts.every(artifact => !Object.prototype.hasOwnProperty.call(artifact, 'sourceLabel'))).toBe(true)
   })
 

--- a/src/tests/wolvesLoreColumn.test.ts
+++ b/src/tests/wolvesLoreColumn.test.ts
@@ -5,6 +5,7 @@ import { mount } from '@vue/test-utils'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getChatlogLore, getQuoteLore, loreRecords } from '../components/wolves/lore'
 import {
+  BLOCK_OVERHEAD_CHARACTERS,
   CHAT_PAGE_CHARACTERS,
   estimatePageSeconds,
   estimatePagesSeconds,
@@ -385,7 +386,7 @@ describe('wolvesLoreColumn Logic', () => {
 
   it('never splits a quote that fits one page', () => {
     const shortQuotes = loreRecords.filter(record =>
-      record.kind === 'quote' && record.body.length <= PROSE_PAGE_CHARACTERS,
+      record.kind === 'quote' && record.body.length + BLOCK_OVERHEAD_CHARACTERS <= PROSE_PAGE_CHARACTERS,
     )
 
     expect(shortQuotes.length).toBeGreaterThan(0)

--- a/src/tests/wolvesLoreRecords.test.ts
+++ b/src/tests/wolvesLoreRecords.test.ts
@@ -79,7 +79,7 @@ describe('wolves lore records', () => {
     const laura = records.find(record => record.id === 'laura-sherman-robert')
     const openssf = records.find(record => record.id === 'openssf-reinforcements')
 
-    expect(records).toHaveLength(64)
+    expect(records).toHaveLength(65)
     expect(records.flatMap(record => record.diagnostics)).toEqual([])
     expect(artifact).toMatchObject({
       chapterId: 'prologue',
@@ -130,7 +130,7 @@ describe('wolves lore records', () => {
   it('loads every quote with authored identity and no diagnostics', () => {
     const quotes = loadAllLoreRecords().filter(record => record.kind === 'quote')
 
-    expect(quotes).toHaveLength(17)
+    expect(quotes).toHaveLength(18)
     for (const quote of quotes) {
       expect(quote.metadata.attribution, quote.relativePath).toEqual(expect.any(String))
       expect(quote.metadata.attribution?.trim(), quote.relativePath).not.toBe('')

--- a/src/tests/wolvesStory.test.ts
+++ b/src/tests/wolvesStory.test.ts
@@ -20,6 +20,7 @@ describe('wolves story manifest', () => {
         'forbidden-factory',
         'jordan-adrian',
         'arthur-c-clarke-3',
+        'arthur-c-clarke-4',
         'maintenance-window'
       ])
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from 'vite'
-import { resolve } from 'node:path'
 import { fileURLToPath, URL } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
 import { createVitestExclude } from './scripts/lib/vitest-exclude.js'
+import { createDirectoryEntryPaths, createRollupInput } from './scripts/lib/site-entries.js'
 
-const directoryEntryPaths = new Set(['/dakota', '/server', '/wolves'])
+const directoryEntryPaths = createDirectoryEntryPaths()
 
 function redirectDirectoryEntries(): Plugin {
   return {
@@ -72,14 +72,7 @@ export default defineConfig({
   ],
   build: {
     rollupOptions: {
-      input: {
-        'main': resolve(__dirname, 'index.html'),
-        'testing': resolve(__dirname, 'public/testing.html'),
-        'dakota': resolve(__dirname, 'dakota/index.html'),
-        'server': resolve(__dirname, 'server/index.html'),
-        'wolves': resolve(__dirname, 'wolves/index.html'),
-        'wolves/experience': resolve(__dirname, 'wolves/experience/index.html'),
-      },
+      input: createRollupInput(__dirname),
       output: {
         manualChunks: (id: string) => {
           if (['vue', 'vue-i18n'].some(mod => id.includes(`/node_modules/${mod}`))) {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,8 +3,8 @@ import { fileURLToPath, URL } from 'node:url'
 import tailwindcss from '@tailwindcss/vite'
 import vue from '@vitejs/plugin-vue'
 import { defineConfig } from 'vite'
-import { createVitestExclude } from './scripts/lib/vitest-exclude.js'
 import { createDirectoryEntryPaths, createRollupInput } from './scripts/lib/site-entries.js'
+import { createVitestExclude } from './scripts/lib/vitest-exclude.js'
 
 const directoryEntryPaths = createDirectoryEntryPaths()
 


### PR DESCRIPTION
Final-review consolidation of the five batch pull requests for this repository, with the defects found in audit repaired. Supersedes #783, #784, #785, #786, #787.

## Included changes

- **#776 — vite entry consolidation** (from #783): single source of truth in `scripts/lib/site-entries.js` for `build.rollupOptions.input` and `directoryEntryPaths`, so `/wolves/experience` can no longer drift out of the dev-server redirect set. Drift test included.
- **#769 — pinned growth chart** (from #784): `update-content.yml` now calls `node scripts/update-growth-chart.js` (merged in #771) instead of an unpinned `curl` from `ublue-os/countme:main` with no integrity check.
- **#780 — version-projection drift gate** (from #785): new contract test asserting `DAKOTA_KEYS`/`PACKAGE_LABELS` in `SectionPicker.vue` and `VersionInfo` in `ImageChooser.vue` resolve against `IMAGE_SBOM_REGISTRY`.
- **#755 — register arthur-c-clarke-4** (from #786): adds the authored lore record to the manifest; count assertions updated.
- **#748 — album slide pacing decoupled** (from #787): `currentTrack` resolves only for the Wolves experience; generic albums run the stable `[7, 8, 10]` hold cadence instead of borrowing the Wolves manifest tempo by index. Reference doc updated.

## Audit repairs on top of the batch heads

1. `fix(wolves): restore currentTrack computed closing brace` — #787's head dropped the `})` closing the `currentTrack` computed; the SFC failed to parse (`vite:vue` Unexpected token, eslint parsing error at `WolvesComicReader.vue:1497`), failing both `test` and `wolves-movie-flow`.
2. `fix(wolves): align one-page quote classifier with block overhead` — #786's head failed `wolvesLoreColumn.test.ts` "never splits a quote that fits one page": the gate classified quotes by `body.length <= PROSE_PAGE_CHARACTERS` (190) while the page model fits a block only when `body + BLOCK_OVERHEAD_CHARACTERS (40) <= 190`. The 177-char Clarke quote sits in the gap band and correctly pages to two; the classifier now uses the model's own criterion (`BLOCK_OVERHEAD_CHARACTERS` exported for the test).
3. `fix(build): satisfy lint in site entries consolidation` — #783's head failed lint with `prefer-template`, `dot-notation`, and `perfectionist/sort-imports` errors in its own files.
4. `chore(scripts): add JSDoc @returns descriptions in site-entries.js` — satisfies `jsdoc/require-returns-description` so warnings remain flat with `main` at 25.

## Validation (consolidated head 9d32ddf2)

- `npm run lint` — 0 errors (25 pre-existing JSDoc warnings, unchanged from main).
- `npm run typecheck` — clean.
- `npx vitest run` — 102 files, 1276 passed, 1 skipped (skipIf CI), 0 failed (incl. the new drift gates and the repaired pagination test).
- `npm run build` — all six entries build.
- `npm run test:gate` not runnable here: it shells out to `yt-dlp`, which this host lacks (the known host-environment gap tracked in #766).

Closes projectbluefin/website#776
Closes projectbluefin/website#769
Closes projectbluefin/website#780
Closes projectbluefin/website#755
Closes projectbluefin/website#748
