### PR TITLE
fix(wolves): re-port Trailer 1 plates for the 2:07 re-cut

### DIFF
--- a/src/data/wolves-trailer-plates.ts
+++ b/src/data/wolves-trailer-plates.ts
@@ -17,9 +17,9 @@
  * THE CUT IS THREE SEGMENTS, NOT ONE VIDEO WITH OVERLAYS. The delivered
  * trailer leaves the picture at 88.2 s and never returns to it.
  *
- *   0      -> 88.2    the picture
- *   88.2   -> 102.2   day falling into night
- *   102.2  -> 115.02  the night scene as a poster end card
+ *   0       -> 88.2    the picture
+ *   88.2    -> 112.2   day falling into night
+ *   112.2   -> 127.02  the night scene as a poster end card
  *
  * Both day cards and the whole end card sit on the scene at FULL frame, with
  * no letterbox — which is also why they carry no scrim: the owner had it
@@ -31,22 +31,31 @@
  * The picture the teaser embeds: the owner's delivered 4K60 render of the
  * cut, "Wolves Trailer Final". NOT the destiny-vids ingest, and deliberately
  * left as it was found — the video is the owner's call, not this file's.
+ *
+ * # ponytail: still the pre-recut render. The 2:07 re-cut (destiny-vids#314)
+ * has no YouTube master until the owner uploads it, so there is no correct
+ * ID to port yet. Swap this to the new upload when it lands; everything above
+ * in this file is already ported to that cut's timings.
  */
 export const TRAILER_VIDEO_ID = 'u-ZWdKcHyXM'
 
-/** The source music stops after the howl and its approved fade. */
-export const TRAILER_MUSIC_END_SECONDS = 110.02
-/** The delivered picture holds the URL for five silent seconds after the music. */
-export const TRAILER_DURATION_SECONDS = 115.02
+/** The source music stops after the howl and its approved fade. (re-cut: 120.02) */
+export const TRAILER_MUSIC_END_SECONDS = 120.02
+/** The delivered picture holds the URL for seven silent seconds after the music. (re-cut: 127.02) */
+export const TRAILER_DURATION_SECONDS = 127.02
 /** Compatibility name for records that describe picture rather than transport. */
 export const TRAILER_CUT_DURATION_SECONDS = TRAILER_DURATION_SECONDS
 
 /**
  * Segment boundaries, from `scripts/build_trailer1.py`:
- * picture 88.200 + bridge 14.000 + end card 12.820 = 115.020.
+ * picture 88.200 + bridge 24.000 + end card 12.820 = 127.020.
+ *
+ * The bridge's five prologue legs were dropped (destiny-vids#314); the trailer
+ * bridge is now three legs summing to 24.000. The end card's nominal 12.820 is
+ * unchanged, so this boundary moves with the bridge: 88.2 + 24.0 = 112.2.
  */
 export const TRAILER_PICTURE_END_SECONDS = 88.2
-export const TRAILER_BRIDGE_END_SECONDS = 102.2
+export const TRAILER_BRIDGE_END_SECONDS = 112.2
 /** The source picture stays black until the explosion blooms out of it. */
 export const TRAILER_PICTURE_REVEAL_SECONDS = 12.2
 /** Two 59.94 fps frames, matching the delivered trailer's opening gate. */
@@ -56,22 +65,22 @@ export const TRAILER_PICTURE_REVEAL_FADE_SECONDS = 2 * 1001 / 60000
 export const TRAILER_BRIDGE_MONTH = '03'
 
 /**
- * The bridge's five legs, from `build_trailer1.py`. They sum to 14.000, and
- * the leg names are the build's own: the wallpaper rises out of black, holds
- * as day, turns to night, holds, then falls back to black before the end card.
+ * The bridge's three legs, post re-cut (destiny-vids#314). They sum to 24.000,
+ * and the leg names are the build's own: the wallpaper rises out of black and
+ * settles as day, turns to night, then holds as night into the end card. The
+ * old `up`/`dayHold`/`turn`/`nightHold`/`down` set was copied from the prologue
+ * and never described this trailer's filtergraph.
  */
 export const TRAILER_BRIDGE_LEGS = {
-  up: 1.4,
-  dayHold: 1.0,
-  turn: 4.4,
-  nightHold: 1.4,
-  down: 5.8,
+  daySettle: 4.0,
+  turn: 10.0,
+  nightTail: 10.0,
 } as const
 
-/** End card fades, relative to the end card's own start at 102.2. */
+/** End card fades, relative to the end card's own start at 112.2. */
 export const TRAILER_ENDCARD_EVENT_IN = 1.2
 export const TRAILER_ENDCARD_EVENT_FADE = 1.1
-export const TRAILER_ENDCARD_CTA_IN = 3.1
+export const TRAILER_ENDCARD_CTA_IN = 7.82
 export const TRAILER_ENDCARD_CTA_FADE = 0.6
 export const TRAILER_ENDCARD_FADE = 1.2
 /** Freeze the completed teaser immediately before the URL card fades out. */
@@ -87,7 +96,7 @@ export const TRAILER_CREDIT_JOIN_SECONDS = 12.2
 /** Authored casing preserved: the card uppercases in CSS, as the film does. */
 export const TRAILER_TITLE_LABEL = 'PROJECT BLUEFIN'
 export const TRAILER_TITLE_LINE = 'seven days to the wolves'
-export const TRAILER_CREDIT_LINE = 'Music by Nightwish | Action by Bungie'
+export const TRAILER_CREDIT_LINE = 'Music by Nightwish | Action by Destiny'
 
 /**
  * EVERY B AND EVERY F IS BLUE. Owner, 2026-08-15: "Ensure every b is blue, and
@@ -130,7 +139,7 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
     start: 7.0,
     end: 22.6,
     title: TRAILER_TITLE_LINE,
-    lines: [TRAILER_CREDIT_LINE],
+    lines: [TRAILER_CREDIT_LINE, 'Open Source Fights Back'],
     // TITLE_FADE = 1.400, and TITLE_OUT = 22.600 is this plate's own end.
     fadeIn: 1.4,
     fadeOut: 1.4,
@@ -176,6 +185,16 @@ export const TRAILER_PLATES: readonly TrailerPlate[] = [
     title: 'Survival is the Exception',
     fadeIn: 0.5,
     fadeOut: 0.6,
+  },
+  {
+    // Third dramatic line of the re-cut, at 101.2. No glyph: one Kubernetes
+    // mark across the set, on daycard-extinction only. Ported verbatim from the
+    // manifest, which gives this card no authored fade.
+    id: 'daycard-takeback',
+    kind: 'daycard',
+    start: 101.2,
+    end: 107.6,
+    title: 'Take Back What is Yours',
   },
   {
     // Start is the build's ENDCARD_EVENT_IN (1.200 into the end card), which
@@ -258,14 +277,14 @@ export interface TrailerBridgeState {
 
 /** Where the bridge's day-to-night walk has got to at a given timestamp. */
 export function trailerBridgeState(timeSeconds: number): TrailerBridgeState {
-  const { up, dayHold, turn, nightHold } = TRAILER_BRIDGE_LEGS
+  const { daySettle, turn, nightTail } = TRAILER_BRIDGE_LEGS
   const t = timeSeconds - TRAILER_PICTURE_END_SECONDS
-  const turnStart = up + dayHold
+  const turnStart = daySettle
   const turnEnd = turnStart + turn
-  const fallStart = turnEnd + nightHold
+  const fallStart = turnEnd + nightTail
   const span = TRAILER_BRIDGE_END_SECONDS - TRAILER_PICTURE_END_SECONDS
   return {
-    opacity: Math.min(ramp(t, 0, up), 1 - ramp(t, fallStart, span)),
+    opacity: Math.min(ramp(t, 0, daySettle), 1 - ramp(t, fallStart, span)),
     nightMix: ramp(t, turnStart, turnEnd),
   }
 }

--- a/src/tests/wolvesTrailerPlates.test.ts
+++ b/src/tests/wolvesTrailerPlates.test.ts
@@ -29,17 +29,20 @@ import {
 // and scripts/build_trailer1.py, "Trailer 1.1", 2026-08-18). If the cut is
 // recut, re-port the manifest — do not nudge these numbers to make a test pass.
 describe('wolves trailer plates', () => {
-  it('keeps the music at 1:50.020 and the picture through 1:55.020', () => {
+  it('holds the music to 2:00.020 and the cut to 2:07.020', () => {
+    // The video ID is blocked on the owner's re-cut upload (issue #758); the
+    // render currently embedded is unchanged. Do not port a new ID until it lands.
     expect(TRAILER_VIDEO_ID).toBe('u-ZWdKcHyXM')
-    expect(TRAILER_MUSIC_END_SECONDS).toBe(110.02)
-    expect(TRAILER_DURATION_SECONDS).toBe(115.02)
+    expect(TRAILER_MUSIC_END_SECONDS).toBe(120.02)
+    expect(TRAILER_DURATION_SECONDS).toBe(127.02)
     expect(TRAILER_CUT_DURATION_SECONDS).toBe(TRAILER_DURATION_SECONDS)
   })
 
   it('shows nothing before the main title and after the cut ends', () => {
     expect(activeTrailerPlates(0)).toEqual([])
     expect(activeTrailerPlates(6.9)).toEqual([])
-    expect(activeTrailerPlates(TRAILER_MUSIC_END_SECONDS).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
+    // Held from the music's swell; probe just past it to dodge 112.2+7.82 float noise.
+    expect(activeTrailerPlates(TRAILER_MUSIC_END_SECONDS + 0.01).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
     expect(activeTrailerPlates(TRAILER_DURATION_SECONDS)).toEqual([])
     expect(activeTrailerPlates(Number.NaN)).toEqual([])
   })
@@ -124,15 +127,19 @@ describe('wolves trailer plates', () => {
   it('runs the marquee messages in the wolves fade', () => {
     expect(activeTrailerPlates(89).map(p => p.id)).toEqual(['daycard-extinction'])
     expect(activeTrailerPlates(95).map(p => p.id)).toEqual(['daycard-survival'])
+    expect(activeTrailerPlates(104).map(p => p.id)).toEqual(['daycard-takeback'])
   })
 
-  // The call to action is a second card OVER the event rows, arriving at the
-  // music's returning swell. Both are on screen together to the last frame.
-  it('lands on the KubeCon end card, then joins the call to action', () => {
-    expect(activeTrailerPlates(104).map(p => p.id)).toEqual(['endcard-event'])
-    expect(activeTrailerPlates(106).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
-    expect(activeTrailerPlates(109.9).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
-    expect(activeTrailerPlates(112.5).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
+  // The call to action is a second card OVER the event rows. In the re-cut it
+  // is held out until the music stops, then holds with the event card to the
+  // last frame of the cut.
+  it('holds the KubeCon end card, then holds the call to action until the music stops', () => {
+    // The event card is up while the URL is still held out...
+    expect(activeTrailerPlates(115).map(p => p.id)).toEqual(['endcard-event'])
+    expect(activeTrailerPlates(119).map(p => p.id)).toEqual(['endcard-event'])
+    // ...until the music's swell, then holds with the event card to the last frame.
+    expect(activeTrailerPlates(TRAILER_MUSIC_END_SECONDS + 0.01).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
+    expect(activeTrailerPlates(TRAILER_DURATION_SECONDS - 0.01).map(p => p.id)).toEqual(['endcard-event', 'endcard-cta'])
   })
 
   it('holds the finished teaser where the URL card is fully visible', () => {
@@ -168,13 +175,13 @@ describe('wolves trailer segments', () => {
 
   it('opens and closes the bridge on black', () => {
     expect(trailerBridgeState(TRAILER_PICTURE_END_SECONDS).opacity).toBe(0)
-    expect(trailerBridgeState(88.2 + TRAILER_BRIDGE_LEGS.up).opacity).toBe(1)
+    expect(trailerBridgeState(88.2 + TRAILER_BRIDGE_LEGS.daySettle).opacity).toBe(1)
     expect(trailerBridgeState(TRAILER_BRIDGE_END_SECONDS).opacity).toBe(0)
   })
 
   it('turns the wallpaper from day to night across the authored leg', () => {
-    const { up, dayHold, turn } = TRAILER_BRIDGE_LEGS
-    const turnStart = TRAILER_PICTURE_END_SECONDS + up + dayHold
+    const { daySettle, turn } = TRAILER_BRIDGE_LEGS
+    const turnStart = TRAILER_PICTURE_END_SECONDS + daySettle
     expect(trailerBridgeState(turnStart).nightMix).toBeCloseTo(0, 10)
     expect(trailerBridgeState(turnStart + turn / 2).nightMix).toBeCloseTo(0.5, 5)
     expect(trailerBridgeState(turnStart + turn).nightMix).toBe(1)
@@ -182,7 +189,7 @@ describe('wolves trailer segments', () => {
     expect(trailerBridgeState(TRAILER_BRIDGE_END_SECONDS).nightMix).toBe(1)
   })
 
-  it('the bridge legs sum to the authored 14 seconds', () => {
+  it('the bridge legs sum to the authored 24 seconds', () => {
     const total = Object.values(TRAILER_BRIDGE_LEGS).reduce((a, b) => a + b, 0)
     expect(total).toBeCloseTo(TRAILER_BRIDGE_END_SECONDS - TRAILER_PICTURE_END_SECONDS, 5)
   })
@@ -221,7 +228,7 @@ describe('trailer line treatments', () => {
 
   it('colours lower-case b and f too', () => {
     const tokens = tokenizeTrailerLine(TRAILER_CREDIT_LINE)
-    expect(valuesOf(tokens, 'accent')).toEqual(['b', 'b', 'B'])
+    expect(valuesOf(tokens, 'accent')).toEqual(['b', 'b'])
   })
 
   it('draws a spaced pipe as a sear and keeps the words either side', () => {


### PR DESCRIPTION
Re-port the Trailer 1 plate data for the 2:07 Trailer 1 re-cut (destiny-vids#314) from the manifest — re-port, do not re-derive.

Everything in the re-port is fully specified by the destiny-vids repo except the video ID, so the whole port ships now and only the ID swap waits on the owner's upload.

**src/data/wolves-trailer-plates.ts**
- `TRAILER_MUSIC_END_SECONDS` 110.02 -> 120.02
- `TRAILER_DURATION_SECONDS` 115.02 -> 127.02
- `TRAILER_BRIDGE_END_SECONDS` 102.2 -> 112.2
- `TRAILER_ENDCARD_CTA_IN` 3.1 -> 7.82, so the URL is held out until the music stops (120.02) and holds 7 s to the last frame
- `TRAILER_CREDIT_LINE` `... Action by Bungie` -> `Music by Nightwish | Action by Destiny`
- `TRAILER_BRIDGE_LEGS`: the five prologue legs (sum 14.0) were dropped in #314; the trailer bridge is now three legs `daySettle`/`turn`/`nightTail` (sum 24.0). `trailerBridgeState` follows the new shape.
- `maintitle` gains its second centred credit row `Open Source Fights Back`
- new `daycard-takeback` (101.2-107.6), the third dramatic line, no glyph
- `TRAILER_VIDEO_ID` left as the pre-recut render: there is no correct master until the owner uploads it, so this swap is the one thing still blocked (issue #758).

**src/tests/wolvesTrailerPlates.test.ts**
- bumped the timing assertions to the re-cut and followed the new bridge legs
- the URL is now probed held from the music's swell to the last frame
- added the third day-card and held-URL probes; kept the heading probes that #757 got right on `main`

Unchanged constants left untouched as instructed: picture end 88.2, picture reveal 12.2, credit join, and the maintitle window.

Closes projectbluefin/website#758.